### PR TITLE
Introduce cross-building to newer Scala version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,10 @@
-import Settings._
-import Version._
-
 name         := "scala-circuit-breaker"
 organization := "com.hootsuite"
 organizationName := "Hootsuite Media Inc."
 organizationHomepage := Some(url("http://hootsuite.com"))
 version      := Version.project
 scalaVersion := Version.scala
+crossScalaVersions in ThisBuild := Seq(Version.previousScala, Version.scala)
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
 
@@ -17,7 +15,7 @@ libraryDependencies ++= Seq(
   "org.slf4j"         %  "slf4j-api"        % "1.7.13",
   "ch.qos.logback"    %  "logback-core"     % "1.1.3",
   "ch.qos.logback"    %  "logback-classic"  % "1.1.3",
-  "org.scalatest"     %% "scalatest"        % "2.2.6"   % Test
+  "org.scalatest"     %% "scalatest"        % "3.0.1"   % Test
 )
 
 Settings.publishSettings

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,4 +1,5 @@
 object Version {
   val project = "1.0.1"
-  val scala = "2.11.7"
+  val previousScala = "2.11.11"
+  val scala = "2.12.3"
 }


### PR DESCRIPTION
With the release of Scala 2.12, the projects I've been using the
circuit-breaker in, are not able to update. Therefore I added a
cross-build setting to the sbt configuration for the current and
previous version of Scala. The tests still pass for both versions
(after updating scalatest).

It would be great to be able to use this library going forward with
an Scala update.