### PR TITLE
Expose new isWaiting method on ReadOnlyCircuitBreakerSnapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
+## 1.0.4
+
+- Add `isWaiting` to `ReadOnlyCircuitBreakerSnapshot` that will return `true` if the Circuit Breaker is OPEN/BROKEN and the `retryDelay` has passed, but no additional invocation has been made yet that could close the breaker again.
+    - This can be useful when using `CircuitBreakerRegistry.get` in something like a status check when there is a very low volume of calls flowing through the Circuit Breaker. A Circuit Breaker that is waiting to try another call may not indicate an alertable error.
+
 ## 1.0.3
+
 - No changes were made to the code. JCenter wasn't showing up the new library version.
 
 ## 1.0.2

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#Circuit Breaker
+# Circuit Breaker
 
-## What is Circuit Breaker?
+## What is a Circuit Breaker?
 
-Circuit breaker monitors number of failed requests and decides to delay sending further requests
+A circuit breaker monitors the number of failed requests and decides to delay sending further requests
 based on configurable threshold. Read more about [circuit breakers](http://martinfowler.com/bliki/CircuitBreaker.html).
 Failure threshold, delay time, failure criteria, and event listeners are configurable in config file and code.
 

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,5 +1,5 @@
 object Version {
-  val project = "1.0.3"
+  val project = "1.0.4"
   val previousScala = "2.11.11"
   val scala = "2.12.3"
 }

--- a/src/main/scala/com/hootsuite/circuitbreaker/CircuitBreakerRegistry.scala
+++ b/src/main/scala/com/hootsuite/circuitbreaker/CircuitBreakerRegistry.scala
@@ -63,11 +63,15 @@ object CircuitBreakerRegistry {
   private[circuitbreaker] def clear(): Unit = circuitBreakerStore.clear()
 }
 
-private case class ClonedCircuitBreaker(name: String, isFlowing: Boolean, isBroken: Boolean)
-  extends ReadOnlyCircuitBreakerSnapshot
+private case class ClonedCircuitBreaker(
+  name: String,
+  isFlowing: Boolean,
+  isBroken: Boolean,
+  isWaiting: Boolean
+) extends ReadOnlyCircuitBreakerSnapshot
 
 private object ClonedCircuitBreaker {
 
   def apply(cb: ReadOnlyCircuitBreakerSnapshot): ClonedCircuitBreaker =
-    new ClonedCircuitBreaker(cb.name, cb.isFlowing, cb.isBroken)
+    new ClonedCircuitBreaker(cb.name, cb.isFlowing, cb.isBroken, cb.isWaiting)
 }

--- a/src/main/scala/com/hootsuite/circuitbreaker/ReadOnlyCircuitBreakerSnapshot.scala
+++ b/src/main/scala/com/hootsuite/circuitbreaker/ReadOnlyCircuitBreakerSnapshot.scala
@@ -11,16 +11,26 @@ trait ReadOnlyCircuitBreakerSnapshot {
   def name: String
 
   /**
-    * Whether or not this circuit breaker is closed/flowing
+    * Whether this circuit breaker is closed/flowing.
     *
     * @return true if it is, false otherwise
     */
   def isFlowing: Boolean
 
   /**
-    * Whether or not the circuit breaker is opened/broken
+    * Whether this circuit breaker is opened/broken.
     *
     * @return true if it is, false otherwise
     */
   def isBroken: Boolean
+
+  /**
+    * Whether this circuit breaker is opened/broken, but enough
+    * time has elapsed that the next invocation will cause a retry.
+    *
+    * Note: `isBroken` will still return `true` when this returns `true`.
+    *
+    * @return true if it is waiting to retry, false otherwise
+    */
+  def isWaiting: Boolean
 }

--- a/src/test/scala/com/hootsuite/circuitbreaker/CircuitBreakerRegistryTest.scala
+++ b/src/test/scala/com/hootsuite/circuitbreaker/CircuitBreakerRegistryTest.scala
@@ -14,18 +14,20 @@ class CircuitBreakerRegistryTest extends FlatSpec with Matchers with BeforeAndAf
 
   val retryDelay = Duration(100, TimeUnit.MILLISECONDS)
 
+  private def waitUntilRetryDelayHasExpired() = Thread.sleep(2 * retryDelay.toMillis)
+
   "registry" should "be empty on startup" in {
     CircuitBreakerRegistry.getAll.isEmpty shouldEqual true
   }
 
   it should "store a circuit breaker in the registry" in {
-    new CircuitBreakerBuilder("test", 1, retryDelay).build()
+    CircuitBreakerBuilder("test", 1, retryDelay).build()
     CircuitBreakerRegistry.getAll.size shouldEqual 1
   }
 
   it should "allow retrieval of an already stored circuit breaker" in {
     val name = "the name"
-    new CircuitBreakerBuilder(name, 1, retryDelay).build()
+    CircuitBreakerBuilder(name, 1, retryDelay).build()
     val retrieved = CircuitBreakerRegistry.get(name)
 
     retrieved should be('defined)
@@ -39,7 +41,7 @@ class CircuitBreakerRegistryTest extends FlatSpec with Matchers with BeforeAndAf
 
   it should "allow removal of circuit breaker by name" in {
     val name = "the name"
-    new CircuitBreakerBuilder(name, 1, retryDelay).build()
+    CircuitBreakerBuilder(name, 1, retryDelay).build()
     CircuitBreakerRegistry.getAll should not be 'empty
     val removed = CircuitBreakerRegistry.remove(name)
 
@@ -48,7 +50,7 @@ class CircuitBreakerRegistryTest extends FlatSpec with Matchers with BeforeAndAf
   }
 
   it should "allow removal of circuit breaker by reference" in {
-    val circuitBreaker = new CircuitBreakerBuilder("a name", 1, retryDelay).build()
+    val circuitBreaker = CircuitBreakerBuilder("a name", 1, retryDelay).build()
     CircuitBreakerRegistry.getAll should not be 'empty
     val removed = CircuitBreakerRegistry.remove(circuitBreaker)
 
@@ -57,8 +59,8 @@ class CircuitBreakerRegistryTest extends FlatSpec with Matchers with BeforeAndAf
   }
 
   it should "allow registering multiple circuit breakers" in {
-    new CircuitBreakerBuilder("one", 1, retryDelay).build()
-    new CircuitBreakerBuilder("two", 1, retryDelay).build()
+    CircuitBreakerBuilder("one", 1, retryDelay).build()
+    CircuitBreakerBuilder("two", 1, retryDelay).build()
 
     CircuitBreakerRegistry.getAll.size should be(2)
     CircuitBreakerRegistry.get("one") should be('defined)
@@ -67,7 +69,7 @@ class CircuitBreakerRegistryTest extends FlatSpec with Matchers with BeforeAndAf
 
   it should "return a read-once version of the underlying circuit breaker" in {
     val name = "trip fast"
-    val actualCircuitBreaker = new CircuitBreakerBuilder(name, 1, retryDelay).build()
+    val actualCircuitBreaker = CircuitBreakerBuilder(name, 1, retryDelay).build()
 
     val lookedUpCircuitBreaker =
       CircuitBreakerRegistry.get(name).getOrElse(throw new Exception("should've found this!"))
@@ -76,19 +78,23 @@ class CircuitBreakerRegistryTest extends FlatSpec with Matchers with BeforeAndAf
     actualCircuitBreaker.isFlowing shouldEqual true
     lookedUpCircuitBreaker.isFlowing shouldEqual actualCircuitBreaker.isFlowing
     lookedUpCircuitBreaker.isBroken shouldEqual actualCircuitBreaker.isBroken
+    lookedUpCircuitBreaker.isWaiting shouldEqual actualCircuitBreaker.isWaiting
 
     //attach an operation so that we can test the circuit breaker
     def myOperation = actualCircuitBreaker() {
       throw new Exception("this is expected")
     }
 
-    //now trip the breaker
+    //now trip the breaker, and wait until retry delay
     Try { myOperation }
     Try { myOperation }
+    waitUntilRetryDelayHasExpired()
 
     actualCircuitBreaker.isFlowing shouldEqual false
+    actualCircuitBreaker.isWaiting shouldEqual true
     lookedUpCircuitBreaker.isFlowing should not be actualCircuitBreaker.isFlowing
     lookedUpCircuitBreaker.isBroken should not be actualCircuitBreaker.isBroken
+    lookedUpCircuitBreaker.isWaiting should not be actualCircuitBreaker.isWaiting
 
     // moral of the story: don't rely on the references returned from the registry; always query the registry
   }


### PR DESCRIPTION
Returns true when the circuit breaker is OPEN/BROKEN, but the retryDelay has passed (meaning the next call that passes through the circuit breaker will not fail-fast). Can be useful for monitoring the
state of the circuit breaker (an OPEN circuit breaker that is just waiting for another call may not
be a critical failure)